### PR TITLE
Apply cargo fmt + clippy baseline for Rust 1.96

### DIFF
--- a/src/auth/jwt.rs
+++ b/src/auth/jwt.rs
@@ -37,10 +37,7 @@ impl JwtKeys {
     }
 }
 
-pub fn issue_token(
-    keys: &JwtKeys,
-    username: &str,
-) -> Result<String, jsonwebtoken::errors::Error> {
+pub fn issue_token(keys: &JwtKeys, username: &str) -> Result<String, jsonwebtoken::errors::Error> {
     let now = OffsetDateTime::now_utc().unix_timestamp();
     let claims = Claims {
         sub: username.to_string(),
@@ -50,10 +47,7 @@ pub fn issue_token(
     encode(&Header::new(Algorithm::HS256), &claims, &keys.encoding)
 }
 
-pub fn validate_token(
-    keys: &JwtKeys,
-    token: &str,
-) -> Result<Claims, jsonwebtoken::errors::Error> {
+pub fn validate_token(keys: &JwtKeys, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
     let validation = Validation::new(Algorithm::HS256);
     decode::<Claims>(token, &keys.decoding, &validation).map(|d| d.claims)
 }

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -43,11 +43,7 @@ pub async fn validator(
 }
 
 fn is_public_path(path: &str) -> bool {
-    if path == "/healthz"
-        || path == "/api/metrics"
-        || path == "/login"
-        || path == "/logout"
-    {
+    if path == "/healthz" || path == "/api/metrics" || path == "/login" || path == "/logout" {
         return true;
     }
     if path.starts_with("/res/") {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -9,7 +9,11 @@ pub use middleware::validator;
 
 /// Read configured username/password from env. Returns None if either is unset/empty.
 pub fn configured_credentials() -> Option<(String, String)> {
-    let user = std::env::var("BASIC_AUTH_USERNAME").ok().filter(|s| !s.is_empty())?;
-    let pass = std::env::var("BASIC_AUTH_PASSWORD").ok().filter(|s| !s.is_empty())?;
+    let user = std::env::var("BASIC_AUTH_USERNAME")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let pass = std::env::var("BASIC_AUTH_PASSWORD")
+        .ok()
+        .filter(|s| !s.is_empty())?;
     Some((user, pass))
 }

--- a/src/bake.rs
+++ b/src/bake.rs
@@ -205,7 +205,7 @@ impl CrawlItem {
 impl Bake for WorkDir {
     fn bake_all(&self) {
         let items = self.crawled.clone();
-        for item in items.values().into_iter() {
+        for item in items.values() {
             if item.previews.is_empty() {
                 let flat_files = item.flat_files();
                 let first_usable_file = flat_files

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -28,11 +28,12 @@ pub async fn login_form(query: web::Query<LoginQuery>) -> impl Responder {
 }
 
 #[post("/login")]
-pub async fn login_submit(
-    req: HttpRequest,
-    form: web::Form<LoginForm>,
-) -> impl Responder {
-    let LoginForm { username, password, next } = form.into_inner();
+pub async fn login_submit(req: HttpRequest, form: web::Form<LoginForm>) -> impl Responder {
+    let LoginForm {
+        username,
+        password,
+        next,
+    } = form.into_inner();
     let safe_next = sanitize_next(next.as_deref());
 
     let (expected_user, expected_pass) = match configured_credentials() {

--- a/src/handlers/blog.rs
+++ b/src/handlers/blog.rs
@@ -8,15 +8,20 @@ use crate::handlers::{calculate_item_index, ExtensionFix, Fa, PaginatorPrefix};
 use crate::site::{CrawlItem, CrawlTag, FileCrawlType};
 
 // Helper functions for rendering blog components
-fn blog_post_card(item: &CrawlItem, site_prefix: &str, config: &ListingPageConfig, position_in_page: usize) -> Markup {
+fn blog_post_card(
+    item: &CrawlItem,
+    site_prefix: &str,
+    config: &ListingPageConfig,
+    position_in_page: usize,
+) -> Markup {
     let time = Utc
-        .timestamp_millis_opt(item.source_published as i64)
+        .timestamp_millis_opt(item.source_published)
         .unwrap();
     // Use item's source site for asset paths
     let asset_site = &item.site_settings.site_slug;
     let slideshow_index = calculate_item_index(config, position_in_page);
-    let first_file_id = crate::handlers::common::get_first_downloaded_file_id(item)
-        .unwrap_or_default();
+    let first_file_id =
+        crate::handlers::common::get_first_downloaded_file_id(item).unwrap_or_default();
     let slideshow_url_path = PageUrlState::slideshow(
         site_prefix.to_string(),
         "blog".to_string(),
@@ -24,7 +29,8 @@ fn blog_post_card(item: &CrawlItem, site_prefix: &str, config: &ListingPageConfi
         slideshow_index,
         first_file_id.clone(),
         ViewMode::Normal,
-    ).to_url();
+    )
+    .to_url();
 
     html! {
         article.blog_post_card {
@@ -139,7 +145,7 @@ pub fn render_detail_page(
     // Use item's source site for asset paths
     let asset_site = &item.site_settings.site_slug;
     let time = Utc
-        .timestamp_millis_opt(item.source_published as i64)
+        .timestamp_millis_opt(item.source_published)
         .unwrap();
 
     let content = html! {
@@ -276,15 +282,13 @@ pub fn render_slideshow_detail_page(
     // Use item's source site for asset paths
     let asset_site = &item.site_settings.site_slug;
     let time = Utc
-        .timestamp_millis_opt(item.source_published as i64)
+        .timestamp_millis_opt(item.source_published)
         .unwrap();
 
     // Get file_id for permalink
     let file_id = item
         .flat_files()
-        .into_iter()
-        .filter(|(_, f)| f.is_downloaded())
-        .next()
+        .into_iter().find(|(_, f)| f.is_downloaded())
         .map(|(id, _)| id);
 
     let content = html! {

--- a/src/handlers/booru.rs
+++ b/src/handlers/booru.rs
@@ -33,12 +33,17 @@ fn booru_layout(title: &str, content: Markup, site: &str, route: &str) -> Markup
     }
 }
 
-fn item_thumbnail(item: &CrawlItem, site_prefix: &str, config: &ListingPageConfig, position_in_page: usize) -> Markup {
+fn item_thumbnail(
+    item: &CrawlItem,
+    site_prefix: &str,
+    config: &ListingPageConfig,
+    position_in_page: usize,
+) -> Markup {
     // Use item's source site for asset paths
     let asset_site = &item.site_settings.site_slug;
     let slideshow_index = calculate_item_index(config, position_in_page);
-    let first_file_id = crate::handlers::common::get_first_downloaded_file_id(item)
-        .unwrap_or_default();
+    let first_file_id =
+        crate::handlers::common::get_first_downloaded_file_id(item).unwrap_or_default();
     let slideshow_url_path = PageUrlState::slideshow(
         site_prefix.to_string(),
         "booru".to_string(),
@@ -46,7 +51,8 @@ fn item_thumbnail(item: &CrawlItem, site_prefix: &str, config: &ListingPageConfi
         slideshow_index,
         first_file_id.clone(),
         ViewMode::Normal,
-    ).to_url();
+    )
+    .to_url();
 
     html! {
         a.item_thumb_container href=(slideshow_url_path) {
@@ -201,8 +207,7 @@ pub fn render_tags_page(
 pub fn render_archive_page(site_prefix: &str, archive: &Vec<ArchiveYear>, route: &str) -> Markup {
     let archive_months = archive
         .iter()
-        .map(|year| year.months.iter())
-        .flatten()
+        .flat_map(|year| year.months.iter())
         .collect::<Vec<_>>();
 
     let content = html! {
@@ -239,9 +244,7 @@ pub fn render_slideshow_detail_page(
     // Get file_id for permalink
     let file_id = item
         .flat_files()
-        .into_iter()
-        .filter(|(_, f)| f.is_downloaded())
-        .next()
+        .into_iter().find(|(_, f)| f.is_downloaded())
         .map(|(id, _)| id);
 
     let content = html! {

--- a/src/handlers/common.rs
+++ b/src/handlers/common.rs
@@ -2,9 +2,9 @@ use actix_web::web;
 
 // Common error response for locked workdir
 pub fn workdir_locked_error() -> actix_web::Error {
-    actix_web::Error::from(actix_web::error::ErrorServiceUnavailable(
+    actix_web::error::ErrorServiceUnavailable(
         "Work directory is locked",
-    ))
+    )
 }
 
 // Helper function to get workdir from ThreadSafeWorkDir
@@ -38,9 +38,9 @@ pub fn date_time_element(timestamp: Option<u64>) -> maud::Markup {
 
 /// Get the first downloaded file ID from an item
 pub fn get_first_downloaded_file_id(item: &crate::site::CrawlItem) -> Option<String> {
-    use indexmap::IndexMap;
     use crate::site::FileCrawlType;
-    
+    use indexmap::IndexMap;
+
     item.flat_files()
         .into_iter()
         .filter(|(_, file)| file.is_downloaded())

--- a/src/handlers/generic.rs
+++ b/src/handlers/generic.rs
@@ -19,8 +19,8 @@ use urlencoding::decode;
 pub struct RemoteAssetBaseUrl(pub String);
 
 use super::{
-    ListingPageConfig, ListingPageMode, ListingPageOrdering, PageUrlState, SiteRenderer, SiteRendererType,
-    SiteSource, ViewMode,
+    ListingPageConfig, ListingPageMode, ListingPageOrdering, PageUrlState, SiteRenderer,
+    SiteRendererType, SiteSource, ViewMode,
 };
 
 fn resolve_listing_page(site_source: &SiteSource, mode: &ListingPageMode) -> Vec<CrawlItem> {
@@ -39,7 +39,7 @@ fn resolve_listing_page(site_source: &SiteSource, mode: &ListingPageMode) -> Vec
             .filter(|item| {
                 let date = item.source_published;
                 let date = DateTime::from_timestamp_millis(date).unwrap();
-                date.year() as u32 == *year && date.month() as u32 == *month
+                date.year() as u32 == *year && date.month() == *month
             })
             .collect(),
 
@@ -133,7 +133,7 @@ pub async fn generic_random_handler(
     };
     let items = apply_selection(&items, &config);
 
-    renderer.render_listing_page(&site_prefix, config, &items, &format!("/random"))
+    renderer.render_listing_page(&site_prefix, config, &items, "/random")
 }
 
 #[get("/latest")]
@@ -153,7 +153,7 @@ pub async fn generic_latest_handler(
     };
     let items = apply_selection(&items, &config);
 
-    renderer.render_listing_page(&site_prefix, config, &items, &format!("/latest"))
+    renderer.render_listing_page(&site_prefix, config, &items, "/latest")
 }
 
 #[get("/latest/{page}")]
@@ -168,7 +168,7 @@ pub async fn generic_latest_page_handler(
     let config = ListingPageConfig {
         mode: ListingPageMode::All,
         ordering: ListingPageOrdering::NewestFirst,
-        page: page.clone(),
+        page: *page,
         per_page: 15,
         total: items.len(),
     };
@@ -194,7 +194,7 @@ pub async fn generic_oldest_handler(
     };
     let items = apply_selection(&items, &config);
 
-    renderer.render_listing_page(&site_prefix, config, &items, &format!("/oldest"))
+    renderer.render_listing_page(&site_prefix, config, &items, "/oldest")
 }
 
 #[get("/oldest/{page}")]
@@ -209,7 +209,7 @@ pub async fn generic_oldest_page_handler(
     let config = ListingPageConfig {
         mode: ListingPageMode::All,
         ordering: ListingPageOrdering::OldestFirst,
-        page: page.clone(),
+        page: *page,
         per_page: 15,
         total: items.len(),
     };
@@ -274,7 +274,7 @@ pub async fn generic_tags_index_handler(
         tag_names
     };
 
-    renderer.render_tags_page(&site_prefix, &tags, &tag_order, &format!("/tags"))
+    renderer.render_tags_page(&site_prefix, &tags, &tag_order, "/tags")
 }
 #[get("/tag/{tag}")]
 pub async fn generic_tag_handler(
@@ -356,7 +356,7 @@ pub async fn generic_archive_index_handler(
 
         for item in items {
             let time = Utc
-                .timestamp_millis_opt(item.source_published as i64)
+                .timestamp_millis_opt(item.source_published)
                 .unwrap();
             let year = time.year();
             let month = time.month() as u8;
@@ -381,13 +381,13 @@ pub async fn generic_archive_index_handler(
         .group_by(|item| item.year)
         .into_iter()
         .map(|(year, items)| ArchiveYear {
-            year: year,
+            year,
             months: items.cloned().collect(),
         })
         .collect();
     archive_years.sort_by_key(|item| -item.year);
 
-    renderer.render_archive_page(&site_prefix, &archive_years, &format!("/archive"))
+    renderer.render_archive_page(&site_prefix, &archive_years, "/archive")
 }
 
 #[get("/archive/{year}/{month}")]
@@ -472,40 +472,33 @@ pub async fn generic_detail_handler(
 
     let file = { item.flat_files().get(&file_id).unwrap().clone() };
     let is_full = query.view.as_deref() == Some("full");
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::permalink(
         site_prefix.clone(),
         renderer.get_prefix().to_string(),
         id.clone(),
         file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
 
     if is_full {
-        renderer.render_detail_full_page(
-            &site_prefix,
-            &item,
-            &file,
-            &url_state,
-        )
+        renderer.render_detail_full_page(&site_prefix, &item, &file, &url_state)
     } else {
-        renderer.render_detail_page(
-            &site_prefix,
-            &item,
-            &file,
-            &url_state,
-        )
+        renderer.render_detail_page(&site_prefix, &item, &file, &url_state)
     }
 }
-
 
 #[get("/crawled.json")]
 pub async fn serve_crawled_json(
     site_source: web::Data<SiteSource>,
 ) -> Result<impl Responder, actix_web::Error> {
     let json = serde_json::to_string(&site_source.all_items())
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(HttpResponse::Ok()
         .content_type("application/json")
@@ -523,20 +516,29 @@ pub async fn generic_latest_slideshow_redirect_handler(
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
     let i = index.into_inner();
-    
+
     let items = resolve_listing_page(&site_source, &ListingPageMode::All);
     let ordered_items = apply_ordering(&items, &ListingPageOrdering::NewestFirst);
-    
+
     if ordered_items.is_empty() || i == 0 || i > ordered_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &ordered_items[i - 1];
     let file_id = super::common::get_first_downloaded_file_id(current_item);
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/latest/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/latest/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -557,7 +559,10 @@ pub async fn generic_latest_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/latest/slideshow/1", site_prefix, rendering_prefix)))
+            .append_header((
+                "Location",
+                format!("/{}/{}/latest/slideshow/1", site_prefix, rendering_prefix),
+            ))
             .finish();
     }
 
@@ -570,13 +575,25 @@ pub async fn generic_latest_slideshow_handler(
 
     if i > ordered_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/latest/slideshow/{}", site_prefix, rendering_prefix, ordered_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/latest/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    ordered_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &ordered_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < ordered_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < ordered_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -593,7 +610,16 @@ pub async fn generic_latest_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/latest/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/latest/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -609,7 +635,7 @@ pub async fn generic_latest_slideshow_handler(
         per_page: 15,
         total: ordered_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -617,33 +643,51 @@ pub async fn generic_latest_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = ordered_items.get(idx - 1)?;
         let prev_file_id = super::common::get_first_downloaded_file_id(prev_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = ordered_items.get(idx - 1)?;
         let next_file_id = super::common::get_first_downloaded_file_id(next_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {
@@ -679,20 +723,29 @@ pub async fn generic_oldest_slideshow_redirect_handler(
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
     let i = index.into_inner();
-    
+
     let items = resolve_listing_page(&site_source, &ListingPageMode::All);
     let ordered_items = apply_ordering(&items, &ListingPageOrdering::OldestFirst);
-    
+
     if ordered_items.is_empty() || i == 0 || i > ordered_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &ordered_items[i - 1];
     let file_id = super::common::get_first_downloaded_file_id(current_item);
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/oldest/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/oldest/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -713,7 +766,10 @@ pub async fn generic_oldest_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/oldest/slideshow/1", site_prefix, rendering_prefix)))
+            .append_header((
+                "Location",
+                format!("/{}/{}/oldest/slideshow/1", site_prefix, rendering_prefix),
+            ))
             .finish();
     }
 
@@ -726,13 +782,25 @@ pub async fn generic_oldest_slideshow_handler(
 
     if i > ordered_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/oldest/slideshow/{}", site_prefix, rendering_prefix, ordered_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/oldest/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    ordered_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &ordered_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < ordered_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < ordered_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -749,7 +817,16 @@ pub async fn generic_oldest_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/oldest/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/oldest/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -765,7 +842,7 @@ pub async fn generic_oldest_slideshow_handler(
         per_page: 15,
         total: ordered_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -773,34 +850,52 @@ pub async fn generic_oldest_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
-    
+
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = ordered_items.get(idx - 1)?;
         let prev_file_id = super::common::get_first_downloaded_file_id(prev_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = ordered_items.get(idx - 1)?;
         let next_file_id = super::common::get_first_downloaded_file_id(next_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {
@@ -836,7 +931,7 @@ pub async fn generic_search_slideshow_redirect_handler(
     let renderer = renderer.into_inner();
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
-    
+
     // Decode the query
     let decoded_query = match decode(&encoded_query) {
         Ok(decoded) => decoded.to_string(),
@@ -863,11 +958,11 @@ pub async fn generic_search_slideshow_redirect_handler(
     // Sort by source_published (newest first)
     let mut sorted_items = filtered_items;
     sorted_items.sort_by_key(|item| -item.source_published);
-    
+
     if sorted_items.is_empty() || i == 0 || i > sorted_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &sorted_items[i - 1];
     let file_id = current_item
         .flat_files()
@@ -877,10 +972,20 @@ pub async fn generic_search_slideshow_redirect_handler(
         .keys()
         .next()
         .cloned();
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/search/{}/slideshow/{}/{}", site_prefix, rendering_prefix, encoded_query, i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/search/{}/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    encoded_query,
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -901,13 +1006,25 @@ pub async fn generic_search_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/search/{}/slideshow/1", site_prefix, rendering_prefix, encoded_query)))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/search/{}/slideshow/1",
+                    site_prefix, rendering_prefix, encoded_query
+                ),
+            ))
             .finish();
     }
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/search/{}/slideshow/1", site_prefix, rendering_prefix, encoded_query)))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/search/{}/slideshow/1",
+                    site_prefix, rendering_prefix, encoded_query
+                ),
+            ))
             .finish();
     }
 
@@ -944,13 +1061,26 @@ pub async fn generic_search_slideshow_handler(
 
     if i > sorted_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/search/{}/slideshow/{}", site_prefix, rendering_prefix, encoded_query, sorted_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/search/{}/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    encoded_query,
+                    sorted_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &sorted_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < sorted_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < sorted_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -967,7 +1097,17 @@ pub async fn generic_search_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/search/{}/slideshow/{}/{}", site_prefix, rendering_prefix, encoded_query, i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/search/{}/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            encoded_query,
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -985,7 +1125,7 @@ pub async fn generic_search_slideshow_handler(
         per_page: 15,
         total: sorted_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -993,10 +1133,14 @@ pub async fn generic_search_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
-    
+
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = sorted_items.get(idx - 1)?;
@@ -1008,14 +1152,21 @@ pub async fn generic_search_slideshow_handler(
             .keys()
             .next()?
             .clone();
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id.clone(),
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id.clone(),
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = sorted_items.get(idx - 1)?;
@@ -1027,14 +1178,21 @@ pub async fn generic_search_slideshow_handler(
             .keys()
             .next()?
             .clone();
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id.clone(),
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id.clone(),
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {
@@ -1070,20 +1228,29 @@ pub async fn generic_random_slideshow_redirect_handler(
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
     let i = index.into_inner();
-    
+
     let items = resolve_listing_page(&site_source, &ListingPageMode::All);
     let ordered_items = apply_ordering(&items, &ListingPageOrdering::Random);
-    
+
     if ordered_items.is_empty() || i == 0 || i > ordered_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &ordered_items[i - 1];
     let file_id = super::common::get_first_downloaded_file_id(current_item);
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/random/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/random/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -1104,7 +1271,10 @@ pub async fn generic_random_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/random/slideshow/1", site_prefix, rendering_prefix)))
+            .append_header((
+                "Location",
+                format!("/{}/{}/random/slideshow/1", site_prefix, rendering_prefix),
+            ))
             .finish();
     }
 
@@ -1117,13 +1287,25 @@ pub async fn generic_random_slideshow_handler(
 
     if i > ordered_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/random/slideshow/{}", site_prefix, rendering_prefix, ordered_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/random/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    ordered_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &ordered_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < ordered_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < ordered_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -1140,7 +1322,16 @@ pub async fn generic_random_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/random/slideshow/{}/{}", site_prefix, rendering_prefix, i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/random/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -1156,7 +1347,7 @@ pub async fn generic_random_slideshow_handler(
         per_page: 15,
         total: ordered_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -1164,34 +1355,52 @@ pub async fn generic_random_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
-    
+
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = ordered_items.get(idx - 1)?;
         let prev_file_id = super::common::get_first_downloaded_file_id(prev_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = ordered_items.get(idx - 1)?;
         let next_file_id = super::common::get_first_downloaded_file_id(next_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {
@@ -1227,20 +1436,30 @@ pub async fn generic_tag_slideshow_redirect_handler(
     let renderer = renderer.into_inner();
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
-    
+
     let items = resolve_listing_page(&site_source, &ListingPageMode::ByTag { tag: tag.clone() });
     let ordered_items = apply_ordering(&items, &ListingPageOrdering::NewestFirst);
-    
+
     if ordered_items.is_empty() || i == 0 || i > ordered_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &ordered_items[i - 1];
     let file_id = super::common::get_first_downloaded_file_id(current_item);
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/tag/{}/slideshow/{}/{}", site_prefix, rendering_prefix, encode(&tag), i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/tag/{}/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    encode(&tag),
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -1261,7 +1480,15 @@ pub async fn generic_tag_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/tag/{}/slideshow/1", site_prefix, rendering_prefix, encode(&tag))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/tag/{}/slideshow/1",
+                    site_prefix,
+                    rendering_prefix,
+                    encode(&tag)
+                ),
+            ))
             .finish();
     }
 
@@ -1274,13 +1501,26 @@ pub async fn generic_tag_slideshow_handler(
 
     if i > ordered_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/tag/{}/slideshow/{}", site_prefix, rendering_prefix, encode(&tag), ordered_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/tag/{}/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    encode(&tag),
+                    ordered_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &ordered_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < ordered_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < ordered_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -1297,7 +1537,17 @@ pub async fn generic_tag_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/tag/{}/slideshow/{}/{}", site_prefix, rendering_prefix, encode(&tag), i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/tag/{}/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            encode(&tag),
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -1313,7 +1563,7 @@ pub async fn generic_tag_slideshow_handler(
         per_page: 15,
         total: ordered_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -1321,34 +1571,52 @@ pub async fn generic_tag_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
-    
+
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = ordered_items.get(idx - 1)?;
         let prev_file_id = super::common::get_first_downloaded_file_id(prev_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = ordered_items.get(idx - 1)?;
         let next_file_id = super::common::get_first_downloaded_file_id(next_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {
@@ -1384,7 +1652,7 @@ pub async fn generic_archive_slideshow_redirect_handler(
     let renderer = renderer.into_inner();
     let site_prefix = site_source.slug();
     let rendering_prefix = renderer.get_prefix();
-    
+
     let items = resolve_listing_page(
         &site_source,
         &ListingPageMode::ByMonth {
@@ -1393,17 +1661,28 @@ pub async fn generic_archive_slideshow_redirect_handler(
         },
     );
     let ordered_items = apply_ordering(&items, &ListingPageOrdering::NewestFirst);
-    
+
     if ordered_items.is_empty() || i == 0 || i > ordered_items.len() {
         return HttpResponse::NotFound().body("No items found");
     }
-    
+
     let current_item = &ordered_items[i - 1];
     let file_id = super::common::get_first_downloaded_file_id(current_item);
-    
+
     if let Some(file_id) = file_id {
         HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/archive/{}/{}/slideshow/{}/{}", site_prefix, rendering_prefix, year, month, i, encode(&file_id))))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/archive/{}/{}/slideshow/{}/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    year,
+                    month,
+                    i,
+                    encode(&file_id)
+                ),
+            ))
             .finish()
     } else {
         HttpResponse::NotFound().body("No file found for item")
@@ -1424,7 +1703,13 @@ pub async fn generic_archive_slideshow_handler(
 
     if i == 0 {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/archive/{}/{}/slideshow/1", site_prefix, rendering_prefix, year, month)))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/archive/{}/{}/slideshow/1",
+                    site_prefix, rendering_prefix, year, month
+                ),
+            ))
             .finish();
     }
 
@@ -1443,13 +1728,27 @@ pub async fn generic_archive_slideshow_handler(
 
     if i > ordered_items.len() {
         return HttpResponse::SeeOther()
-            .append_header(("Location", format!("/{}/{}/archive/{}/{}/slideshow/{}", site_prefix, rendering_prefix, year, month, ordered_items.len())))
+            .append_header((
+                "Location",
+                format!(
+                    "/{}/{}/archive/{}/{}/slideshow/{}",
+                    site_prefix,
+                    rendering_prefix,
+                    year,
+                    month,
+                    ordered_items.len()
+                ),
+            ))
             .finish();
     }
 
     let current_item = &ordered_items[i - 1];
     let prev_index = if i > 1 { Some(i - 1) } else { None };
-    let next_index = if i < ordered_items.len() { Some(i + 1) } else { None };
+    let next_index = if i < ordered_items.len() {
+        Some(i + 1)
+    } else {
+        None
+    };
 
     // Decode file_id from URL
     let decoded_file_id = match decode(&file_id_param) {
@@ -1466,7 +1765,18 @@ pub async fn generic_archive_slideshow_handler(
             // File not found or not downloaded, redirect to first file
             if let Some(first_file_id) = super::common::get_first_downloaded_file_id(current_item) {
                 return HttpResponse::SeeOther()
-                    .append_header(("Location", format!("/{}/{}/archive/{}/{}/slideshow/{}/{}", site_prefix, rendering_prefix, year, month, i, encode(&first_file_id))))
+                    .append_header((
+                        "Location",
+                        format!(
+                            "/{}/{}/archive/{}/{}/slideshow/{}/{}",
+                            site_prefix,
+                            rendering_prefix,
+                            year,
+                            month,
+                            i,
+                            encode(&first_file_id)
+                        ),
+                    ))
                     .finish();
             } else {
                 return HttpResponse::NotFound().body("No file found for item");
@@ -1485,7 +1795,7 @@ pub async fn generic_archive_slideshow_handler(
         per_page: 15,
         total: ordered_items.len(),
     };
-    
+
     // Construct PageUrlState directly from handler context
     let url_state = PageUrlState::slideshow(
         site_prefix.clone(),
@@ -1493,34 +1803,52 @@ pub async fn generic_archive_slideshow_handler(
         &config,
         i,
         decoded_file_id.clone(),
-        if is_full { ViewMode::Full } else { ViewMode::Normal },
+        if is_full {
+            ViewMode::Full
+        } else {
+            ViewMode::Normal
+        },
     );
     let back_url = url_state.with_view_mode(ViewMode::Normal).to_url();
-    
+
     // For prev/next URLs, we need to get the first file of those items
     let prev_url = prev_index.and_then(|idx| {
         let prev_item = ordered_items.get(idx - 1)?;
         let prev_file_id = super::common::get_first_downloaded_file_id(prev_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            prev_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                prev_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
     let next_url = next_index.and_then(|idx| {
         let next_item = ordered_items.get(idx - 1)?;
         let next_file_id = super::common::get_first_downloaded_file_id(next_item)?;
-        Some(PageUrlState::slideshow(
-            site_prefix.clone(),
-            rendering_prefix.to_string(),
-            &config,
-            idx,
-            next_file_id,
-            if is_full { ViewMode::Full } else { ViewMode::Normal },
-        ).to_url())
+        Some(
+            PageUrlState::slideshow(
+                site_prefix.clone(),
+                rendering_prefix.to_string(),
+                &config,
+                idx,
+                next_file_id,
+                if is_full {
+                    ViewMode::Full
+                } else {
+                    ViewMode::Normal
+                },
+            )
+            .to_url(),
+        )
     });
 
     let markup = if is_full {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -16,7 +16,7 @@ pub use common::*;
 pub use generic::*;
 pub use reddit::media_viewer_fragment_handler;
 pub use search::{search_form_handler, search_results_handler};
-pub use url_state::{PageUrlState, PageType, ViewMode};
+pub use url_state::{PageType, PageUrlState, ViewMode};
 
 use crate::site::{CrawlItem, FileCrawlType};
 
@@ -97,7 +97,7 @@ pub fn format_year_month(year: i32, month: u8) -> String {
 
 pub fn timeago(timestamp: u64) -> Markup {
     let dt =
-        chrono::DateTime::from_timestamp_millis(timestamp as i64).unwrap_or_else(|| Utc::now());
+        chrono::DateTime::from_timestamp_millis(timestamp as i64).unwrap_or_else(Utc::now);
 
     let now = Utc::now().timestamp_millis() as u64;
     let diff = now - timestamp;
@@ -169,7 +169,7 @@ pub fn header(site_prefix: &str, rendering_prefix: &str, current_route: &str) ->
             format!("/{}{}", target_prefix, current_route)
         }
     };
-    
+
     html! {
         header.page-header {
             nav {
@@ -211,7 +211,7 @@ pub fn header(site_prefix: &str, rendering_prefix: &str, current_route: &str) ->
 }
 
 pub fn paginator(page: usize, total: usize, per_page: usize, prefix: &str) -> Markup {
-    let pages = (total + per_page - 1) / per_page;
+    let pages = total.div_ceil(per_page);
     let mut links = vec![];
 
     if page > 1 {
@@ -238,13 +238,13 @@ pub fn paginator(page: usize, total: usize, per_page: usize, prefix: &str) -> Ma
         });
     }
 
-    return html! {
+    html! {
         .paginator {
             @for link in &links {
                 (link)
             }
         }
-    };
+    }
 }
 
 // Common types used across handlers
@@ -451,7 +451,6 @@ impl PaginatorPrefix for ListingPageConfig {
     }
 }
 
-
 /// Calculate the global 1-indexed position of an item in a listing page
 pub fn calculate_item_index(config: &ListingPageConfig, position_in_page: usize) -> usize {
     (config.page - 1) * config.per_page + position_in_page + 1
@@ -549,8 +548,12 @@ impl SiteRenderer for SiteRendererType {
     ) -> Markup {
         match self {
             SiteRendererType::Blog => blog::render_detail_page(site_prefix, item, file, url_state),
-            SiteRendererType::Booru => booru::render_detail_page(site_prefix, item, file, url_state),
-            SiteRendererType::Reddit => reddit::render_detail_page(site_prefix, item, file, url_state),
+            SiteRendererType::Booru => {
+                booru::render_detail_page(site_prefix, item, file, url_state)
+            }
+            SiteRendererType::Reddit => {
+                reddit::render_detail_page(site_prefix, item, file, url_state)
+            }
         }
     }
 
@@ -592,7 +595,9 @@ impl SiteRenderer for SiteRendererType {
     ) -> Markup {
         match self {
             SiteRendererType::Blog => blog::render_detail_page(site_prefix, item, file, url_state),
-            SiteRendererType::Booru => booru::render_detail_page(site_prefix, item, file, url_state),
+            SiteRendererType::Booru => {
+                booru::render_detail_page(site_prefix, item, file, url_state)
+            }
             SiteRendererType::Reddit => {
                 reddit::render_detail_full_page(site_prefix, item, file, url_state)
             }
@@ -609,15 +614,30 @@ impl SiteRenderer for SiteRendererType {
         next_url: Option<&str>,
     ) -> Markup {
         match self {
-            SiteRendererType::Blog => {
-                blog::render_slideshow_detail_page(site_prefix, item, file, url_state, prev_url, next_url)
-            }
-            SiteRendererType::Booru => {
-                booru::render_slideshow_detail_page(site_prefix, item, file, url_state, prev_url, next_url)
-            }
-            SiteRendererType::Reddit => {
-                reddit::render_slideshow_detail_page(site_prefix, item, file, url_state, prev_url, next_url)
-            }
+            SiteRendererType::Blog => blog::render_slideshow_detail_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+            ),
+            SiteRendererType::Booru => booru::render_slideshow_detail_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+            ),
+            SiteRendererType::Reddit => reddit::render_slideshow_detail_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+            ),
         }
     }
 
@@ -632,15 +652,33 @@ impl SiteRenderer for SiteRendererType {
         back_url: &str,
     ) -> Markup {
         match self {
-            SiteRendererType::Blog => {
-                blog::render_slideshow_full_page(site_prefix, item, file, url_state, prev_url, next_url, back_url)
-            }
-            SiteRendererType::Booru => {
-                booru::render_slideshow_full_page(site_prefix, item, file, url_state, prev_url, next_url, back_url)
-            }
-            SiteRendererType::Reddit => {
-                reddit::render_slideshow_full_page(site_prefix, item, file, url_state, prev_url, next_url, back_url)
-            }
+            SiteRendererType::Blog => blog::render_slideshow_full_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+                back_url,
+            ),
+            SiteRendererType::Booru => booru::render_slideshow_full_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+                back_url,
+            ),
+            SiteRendererType::Reddit => reddit::render_slideshow_full_page(
+                site_prefix,
+                item,
+                file,
+                url_state,
+                prev_url,
+                next_url,
+                back_url,
+            ),
         }
     }
 

--- a/src/handlers/reddit.rs
+++ b/src/handlers/reddit.rs
@@ -5,13 +5,12 @@ use std::collections::HashMap;
 use urlencoding::encode;
 
 use super::{
-    ArchiveYear, ListingPageConfig, ListingPageMode, ListingPageOrdering, PageUrlState,
-    SiteSource, ViewMode,
+    ArchiveYear, ListingPageConfig, ListingPageMode, ListingPageOrdering, PageUrlState, SiteSource,
+    ViewMode,
 };
 use crate::collections::GetKey;
 use crate::handlers::{
-    calculate_item_index, format_year_month, timeago, ExtensionFix, Fa,
-    PaginatorPrefix,
+    calculate_item_index, format_year_month, timeago, ExtensionFix, Fa, PaginatorPrefix,
 };
 use crate::site::{CrawlItem, CrawlTag, FileCrawlType};
 
@@ -88,8 +87,8 @@ fn reddit_post_card(
     let asset_site = &item.site_settings.site_slug;
 
     let slideshow_index = calculate_item_index(config, position_in_page);
-    let first_file_id = crate::handlers::common::get_first_downloaded_file_id(item)
-        .unwrap_or_default();
+    let first_file_id =
+        crate::handlers::common::get_first_downloaded_file_id(item).unwrap_or_default();
     let post_href = PageUrlState::slideshow(
         site_prefix.to_string(),
         "r".to_string(),
@@ -97,7 +96,8 @@ fn reddit_post_card(
         slideshow_index,
         first_file_id.clone(),
         ViewMode::Normal,
-    ).to_url();
+    )
+    .to_url();
     let title_id = format!("post-title-{}", encode(&item.key));
 
     html! {
@@ -233,16 +233,14 @@ pub fn post_file_paginator(
     let first_file = flat_files.first();
     let last_file = flat_files.last();
 
-    let file_url = |file_id: &str| {
-        url_state.with_file_id(file_id.to_string()).to_url()
-    };
+    let file_url = |file_id: &str| url_state.with_file_id(file_id.to_string()).to_url();
 
     html! {
         div.post_file_paginator {
             @if let Some(first_file) = first_file {
                 @if first_file.0 != current_file.get_key() {
                     a.first
-                        href=(file_url(&first_file.0))
+                        href=(file_url(first_file.0))
                         data-file-first
                         data-replace-history
                         style="display: none;"
@@ -252,7 +250,7 @@ pub fn post_file_paginator(
             @if let Some(last_file) = last_file {
                 @if last_file.0 != current_file.get_key() {
                     a.last
-                        href=(file_url(&last_file.0))
+                        href=(file_url(last_file.0))
                         data-file-last
                         data-replace-history
                         style="display: none;"
@@ -261,7 +259,7 @@ pub fn post_file_paginator(
             }
             @if let Some(prev_file) = prev_file {
                 a.prev
-                    href=(file_url(&prev_file.0))
+                    href=(file_url(prev_file.0))
                     data-file-prev
                     data-replace-history
                 {
@@ -272,7 +270,7 @@ pub fn post_file_paginator(
             }
             @if let Some(next_file) = next_file {
                 a.next
-                    href=(file_url(&next_file.0))
+                    href=(file_url(next_file.0))
                     data-file-next
                     data-replace-history
                 {
@@ -308,7 +306,7 @@ pub fn render_media_viewer(
                         figure.post_figure {
                             img.post_image src=(format!("/{}/assets/{}", asset_site, filename)) alt=(item.title) {}
                             a.fullscreen_click_target data-toggle-full data-replace-history href=(toggle_url) {}
-                            (post_file_paginator(item, &file, &url_state))
+                            (post_file_paginator(item, file, url_state))
                         }
                     }
                 }
@@ -322,7 +320,7 @@ pub fn render_media_viewer(
                             a.fullscreen_link data-toggle-full data-replace-history href=(toggle_url) {
                                 (Fa("expand"))
                             }
-                            (post_file_paginator(item, &file, url_state))
+                            (post_file_paginator(item, file, url_state))
                         }
                     }
                 }
@@ -374,7 +372,7 @@ pub fn render_full_media_viewer(
                     @if *downloaded {
                         figure.post_figure {
                             img.post_image src=(format!("/{}/assets/{}", asset_site, filename)) alt=(item.title) {}
-                            (post_file_paginator(item, &file, &url_state.with_view_mode(ViewMode::Full)))
+                            (post_file_paginator(item, file, &url_state.with_view_mode(ViewMode::Full)))
                         }
                     }
                 }
@@ -385,7 +383,7 @@ pub fn render_full_media_viewer(
                             video.post_video controls autoplay {
                                 source src=(format!("/{}/assets/{}", asset_site, coerced_filename)) {}
                             }
-                            (post_file_paginator(item, &file, &url_state.with_view_mode(ViewMode::Full)))
+                            (post_file_paginator(item, file, &url_state.with_view_mode(ViewMode::Full)))
                         }
                     }
                 }
@@ -439,7 +437,7 @@ pub fn render_detail_page(
                 @if item.flat_files().iter().filter(|(_, f)| f.is_downloaded()).count() > 0 {
                     a.toggle-full-link data-toggle-full data-replace-history href=(toggle_url) style="display: none;" {}
                 }
-                (render_media_viewer(&item, &file, &url_state))
+                (render_media_viewer(item, file, url_state))
 
                 .post_description {
                     p { (item.description) }
@@ -488,7 +486,7 @@ pub fn render_detail_full_page(
 ) -> Markup {
     let content = html! {
         article.reddit_post_detail_full {
-            (render_full_media_viewer(&item, &file, &url_state, None))
+            (render_full_media_viewer(item, file, url_state, None))
         }
     };
 
@@ -506,7 +504,7 @@ pub fn render_slideshow_full_page(
 ) -> Markup {
     let content = html! {
         article.reddit_post_detail_full {
-            (render_full_media_viewer(&item, &file, &url_state, Some(back_url)))
+            (render_full_media_viewer(item, file, url_state, Some(back_url)))
             .slideshow_navigation {
                 @if let Some(prev) = prev_url {
                     a.slideshow_prev href=(prev) data-item-prev data-replace-history { (Fa("chevron-left")) }
@@ -561,9 +559,7 @@ pub fn render_slideshow_detail_page(
     // Get file_id for permalink
     let file_id = item
         .flat_files()
-        .into_iter()
-        .filter(|(_, f)| f.is_downloaded())
-        .next()
+        .into_iter().find(|(_, f)| f.is_downloaded())
         .map(|(id, _)| id);
 
     let toggle_url = url_state.toggle_view_mode().to_url();
@@ -599,7 +595,7 @@ pub fn render_slideshow_detail_page(
                 @if item.flat_files().iter().filter(|(_, f)| f.is_downloaded()).count() > 0 {
                     a.toggle-full-link data-toggle-full data-replace-history href=(toggle_url) style="display: none;" {}
                 }
-                (render_media_viewer(&item, &file, &url_state))
+                (render_media_viewer(item, file, url_state))
 
                 .post_description {
                     p { (item.description) }
@@ -654,8 +650,7 @@ pub fn render_slideshow_detail_page(
 pub fn render_archive_page(site_prefix: &str, archive: &Vec<ArchiveYear>, route: &str) -> Markup {
     let archive_months = archive
         .iter()
-        .map(|year| year.months.iter())
-        .flatten()
+        .flat_map(|year| year.months.iter())
         .collect::<Vec<_>>();
 
     let content = html! {

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -54,7 +54,7 @@ pub async fn search_form_handler(
                 title { "Search" }
             }
             body.search-page hx-ext="morph" {
-                (header(&site_prefix, &rendering_prefix, "/search"))
+                (header(&site_prefix, rendering_prefix, "/search"))
                 main {
                     .search-page-container {
                         form.search-form-container method="get" action=(format!("/{}/{}/search", site_prefix, rendering_prefix)) {
@@ -129,7 +129,7 @@ pub async fn search_results_handler(
         Err(_) => {
             return error_page(
                 &site_prefix,
-                &rendering_prefix,
+                rendering_prefix,
                 "Invalid URL encoding in search query",
             );
         }
@@ -141,7 +141,7 @@ pub async fn search_results_handler(
         Err(e) => {
             return error_page(
                 &site_prefix,
-                &rendering_prefix,
+                rendering_prefix,
                 &format!("Parse error: {}", e),
             );
         }

--- a/src/handlers/url_state.rs
+++ b/src/handlers/url_state.rs
@@ -71,7 +71,6 @@ impl PageUrlState {
         }
     }
 
-
     /// Change the file_id
     pub fn with_file_id(&self, file_id: String) -> Self {
         Self {
@@ -137,7 +136,11 @@ impl PageUrlState {
     /// Generate the URL string
     pub fn to_url(&self) -> String {
         let base = match &self.page_type {
-            PageType::Slideshow { mode, ordering, index } => {
+            PageType::Slideshow {
+                mode,
+                ordering,
+                index,
+            } => {
                 let slideshow_part = match mode {
                     ListingPageMode::All => match ordering {
                         ListingPageOrdering::NewestFirst => {
@@ -151,27 +154,56 @@ impl PageUrlState {
                         }
                     },
                     ListingPageMode::ByTag { tag } => {
-                        format!("/{}/tag/{}/slideshow/{}", self.rendering_prefix, encode(tag), index)
+                        format!(
+                            "/{}/tag/{}/slideshow/{}",
+                            self.rendering_prefix,
+                            encode(tag),
+                            index
+                        )
                     }
                     ListingPageMode::ByMonth { year, month } => {
-                        format!("/{}/archive/{}/{}/slideshow/{}", self.rendering_prefix, year, month, index)
+                        format!(
+                            "/{}/archive/{}/{}/slideshow/{}",
+                            self.rendering_prefix, year, month, index
+                        )
                     }
                     ListingPageMode::Search { query } => {
-                        format!("/{}/search/{}/slideshow/{}", self.rendering_prefix, encode(query), index)
+                        format!(
+                            "/{}/search/{}/slideshow/{}",
+                            self.rendering_prefix,
+                            encode(query),
+                            index
+                        )
                     }
                 };
 
                 if let Some(ref file_id) = self.file_id {
-                    format!("/{}{}/{}", self.site_prefix, slideshow_part, encode(file_id))
+                    format!(
+                        "/{}{}/{}",
+                        self.site_prefix,
+                        slideshow_part,
+                        encode(file_id)
+                    )
                 } else {
                     format!("/{}{}", self.site_prefix, slideshow_part)
                 }
             }
             PageType::ItemPermalink { item_key } => {
                 if let Some(ref file_id) = self.file_id {
-                    format!("/{}/{}/item/{}/{}", self.site_prefix, self.rendering_prefix, encode(item_key), encode(file_id))
+                    format!(
+                        "/{}/{}/item/{}/{}",
+                        self.site_prefix,
+                        self.rendering_prefix,
+                        encode(item_key),
+                        encode(file_id)
+                    )
                 } else {
-                    format!("/{}/{}/item/{}", self.site_prefix, self.rendering_prefix, encode(item_key))
+                    format!(
+                        "/{}/{}/item/{}",
+                        self.site_prefix,
+                        self.rendering_prefix,
+                        encode(item_key)
+                    )
                 }
             }
         };
@@ -185,7 +217,11 @@ impl PageUrlState {
     /// Generate URL without site prefix (for route parameter)
     pub fn to_route(&self) -> String {
         let base = match &self.page_type {
-            PageType::Slideshow { mode, ordering, index } => {
+            PageType::Slideshow {
+                mode,
+                ordering,
+                index,
+            } => {
                 let slideshow_part = match mode {
                     ListingPageMode::All => match ordering {
                         ListingPageOrdering::NewestFirst => {
@@ -199,13 +235,26 @@ impl PageUrlState {
                         }
                     },
                     ListingPageMode::ByTag { tag } => {
-                        format!("/{}/tag/{}/slideshow/{}", self.rendering_prefix, encode(tag), index)
+                        format!(
+                            "/{}/tag/{}/slideshow/{}",
+                            self.rendering_prefix,
+                            encode(tag),
+                            index
+                        )
                     }
                     ListingPageMode::ByMonth { year, month } => {
-                        format!("/{}/archive/{}/{}/slideshow/{}", self.rendering_prefix, year, month, index)
+                        format!(
+                            "/{}/archive/{}/{}/slideshow/{}",
+                            self.rendering_prefix, year, month, index
+                        )
                     }
                     ListingPageMode::Search { query } => {
-                        format!("/{}/search/{}/slideshow/{}", self.rendering_prefix, encode(query), index)
+                        format!(
+                            "/{}/search/{}/slideshow/{}",
+                            self.rendering_prefix,
+                            encode(query),
+                            index
+                        )
                     }
                 };
 
@@ -217,7 +266,12 @@ impl PageUrlState {
             }
             PageType::ItemPermalink { item_key } => {
                 if let Some(ref file_id) = self.file_id {
-                    format!("/{}/item/{}/{}", self.rendering_prefix, encode(item_key), encode(file_id))
+                    format!(
+                        "/{}/item/{}/{}",
+                        self.rendering_prefix,
+                        encode(item_key),
+                        encode(file_id)
+                    )
                 } else {
                     format!("/{}/item/{}", self.rendering_prefix, encode(item_key))
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,25 +17,21 @@ use std::io::Read;
 use std::{thread, time::Duration};
 
 use site_server::{
-    auth,
-    errors,
+    auth, errors,
     handlers::{
         self, generic_archive_index_handler, generic_archive_page_handler,
         generic_archive_slideshow_handler, generic_archive_slideshow_redirect_handler,
-        generic_latest_slideshow_redirect_handler, generic_oldest_slideshow_redirect_handler,
-        generic_random_slideshow_redirect_handler, generic_tag_slideshow_redirect_handler,
-        generic_search_slideshow_redirect_handler, generic_detail_handler, generic_detail_redirect,
-        generic_index_handler,
+        generic_detail_handler, generic_detail_redirect, generic_index_handler,
         generic_index_root_handler, generic_latest_handler, generic_latest_page_handler,
-        generic_latest_slideshow_handler, generic_oldest_handler,
-        generic_oldest_page_handler, generic_oldest_slideshow_handler,
-        generic_random_handler, generic_random_slideshow_handler,
-        generic_search_slideshow_handler, generic_tag_handler,
-        generic_tag_page_handler, generic_tag_slideshow_handler,
-        generic_tags_index_handler, media_viewer_fragment_handler,
-        remote_asset_proxy_handler, RemoteAssetBaseUrl,
-        search_form_handler,
-        search_results_handler, serve_crawled_json, SiteRenderer, SiteSource,
+        generic_latest_slideshow_handler, generic_latest_slideshow_redirect_handler,
+        generic_oldest_handler, generic_oldest_page_handler, generic_oldest_slideshow_handler,
+        generic_oldest_slideshow_redirect_handler, generic_random_handler,
+        generic_random_slideshow_handler, generic_random_slideshow_redirect_handler,
+        generic_search_slideshow_handler, generic_search_slideshow_redirect_handler,
+        generic_tag_handler, generic_tag_page_handler, generic_tag_slideshow_handler,
+        generic_tag_slideshow_redirect_handler, generic_tags_index_handler,
+        media_viewer_fragment_handler, remote_asset_proxy_handler, search_form_handler,
+        search_results_handler, serve_crawled_json, RemoteAssetBaseUrl, SiteRenderer, SiteSource,
     },
     serve_static_file, thread_safe_work_dir, workdir,
 };
@@ -98,7 +94,7 @@ async fn root_index_handler(
     sites_with_updates
         .sort_by_key(|(_, latest_update)| std::cmp::Reverse(latest_update.unwrap_or(0)));
 
-    return Ok(html! {
+    Ok(html! {
         html {
             head {
                 (handlers::scripts())
@@ -161,7 +157,7 @@ async fn root_index_handler(
                 }
             }
         }
-    });
+    })
 }
 
 #[get("/sites.json")]
@@ -186,7 +182,7 @@ async fn run() -> errors::Result<()> {
         Commands::Bake { work_dirs } => {
             println!("Loading WorkDirs...");
             let mut work_dirs_vec = vec![];
-            for work_dir in work_dirs.into_iter() {
+            for work_dir in work_dirs.iter() {
                 println!("Loading WorkDir: {}", work_dir);
                 let work_dir = WorkDir::new(work_dir.to_string()).expect("Failed to load WorkDir");
                 work_dirs_vec.push(work_dir);
@@ -203,16 +199,15 @@ async fn run() -> errors::Result<()> {
         Commands::Serve { work_dirs } => {
             println!("Loading WorkDirs...");
             let mut work_dirs_vec = vec![];
-            for work_dir in work_dirs.into_iter() {
+            for work_dir in work_dirs.iter() {
                 println!("Loading WorkDir: {}", work_dir);
                 // Load on a separate OS thread so reqwest::blocking doesn't
                 // conflict with the actix async runtime we're inside of.
                 let wd_path = work_dir.to_string();
-                let work_dir = thread::spawn(move || {
-                    WorkDir::new(wd_path).expect("Failed to load WorkDir")
-                })
-                .join()
-                .expect("WorkDir loading thread panicked");
+                let work_dir =
+                    thread::spawn(move || WorkDir::new(wd_path).expect("Failed to load WorkDir"))
+                        .join()
+                        .expect("WorkDir loading thread panicked");
                 let threadsafe_work_dir = ThreadSafeWorkDirImpl::new(work_dir);
                 let update_clone = threadsafe_work_dir.clone();
                 work_dirs_vec.push(threadsafe_work_dir);
@@ -278,11 +273,9 @@ async fn run() -> errors::Result<()> {
                     .service(root_index_handler)
                     .service(sites_json_handler);
 
-                let renderers = vec![
-                    handlers::SiteRendererType::Blog,
+                let renderers = [handlers::SiteRendererType::Blog,
                     handlers::SiteRendererType::Booru,
-                    handlers::SiteRendererType::Reddit,
-                ];
+                    handlers::SiteRendererType::Reddit];
 
                 let site_sources = work_dirs_vec
                     .iter()
@@ -301,7 +294,7 @@ async fn run() -> errors::Result<()> {
                         app = app.service(
                             web::scope(&format!("{}/{}", slug, renderer.get_prefix()))
                                 .app_data(web::Data::new(site_source.clone()))
-                                .app_data(web::Data::new(renderer.clone()))
+                                .app_data(web::Data::new(*renderer))
                                 .app_data(web::Data::new(WorkDirPrefix(slug.clone())))
                                 .service(generic_index_handler)
                                 .service(generic_index_root_handler)
@@ -349,9 +342,7 @@ async fn run() -> errors::Result<()> {
                                 } else if let Some(remote_url) = site_source.get_remote_url() {
                                     // Remote site: proxy asset requests
                                     scope
-                                        .app_data(web::Data::new(RemoteAssetBaseUrl(
-                                            remote_url,
-                                        )))
+                                        .app_data(web::Data::new(RemoteAssetBaseUrl(remote_url)))
                                         .route(
                                             "/assets/{path:.*}",
                                             web::get().to(remote_asset_proxy_handler),

--- a/src/search.rs
+++ b/src/search.rs
@@ -76,12 +76,12 @@ enum Token {
 
 fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
     let mut tokens = Vec::new();
-    let mut chars = input.chars().peekable();
+    let chars = input.chars().peekable();
     let mut current_string = String::new();
     let mut in_string = false;
     let mut escape = false;
 
-    while let Some(ch) = chars.next() {
+    for ch in chars {
         if escape {
             current_string.push(ch);
             escape = false;

--- a/src/site.rs
+++ b/src/site.rs
@@ -65,7 +65,7 @@ impl GetKey for FileCrawlType {
             FileCrawlType::Image { key, .. }
             | FileCrawlType::Video { key, .. }
             | FileCrawlType::Intermediate { key, .. }
-            | FileCrawlType::Text { key, .. } => &key,
+            | FileCrawlType::Text { key, .. } => key,
         }
     }
 }

--- a/src/thread_safe_work_dir.rs
+++ b/src/thread_safe_work_dir.rs
@@ -28,8 +28,8 @@ impl ThreadSafeWorkDir {
         if let Some(ref remote_url) = remote_url {
             // Remote site: check version endpoint
             let version_url = format!("{}/v1/version", remote_url);
-            let version_result = reqwest::blocking::get(&version_url)
-                .and_then(|r| r.json::<serde_json::Value>());
+            let version_result =
+                reqwest::blocking::get(&version_url).and_then(|r| r.json::<serde_json::Value>());
             match version_result {
                 Ok(version) => {
                     let latest_ts = version
@@ -69,7 +69,7 @@ impl ThreadSafeWorkDir {
             }
         } else {
             // Local site: existing file mtime check
-            let latest_ts = std::fs::metadata(&workdir_path.join("crawled.json"))
+            let latest_ts = std::fs::metadata(workdir_path.join("crawled.json"))
                 .ok()
                 .and_then(|m| m.modified().ok())
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())

--- a/src/timestring.rs
+++ b/src/timestring.rs
@@ -402,7 +402,7 @@ fn try_parse_american_date(input: &str, tz: Tz) -> Option<TimeSpec> {
     let day: u32 = caps.get(2)?.as_str().parse().ok()?;
     let year: i32 = caps.get(3)?.as_str().parse().ok()?;
 
-    if month < 1 || month > 12 || day < 1 || day > 31 {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
         return None;
     }
 
@@ -428,7 +428,7 @@ fn try_parse_human_date(input: &str, tz: Tz) -> Option<TimeSpec> {
 
     let month = month_name_to_num(&month_name)?;
 
-    if day < 1 || day > 31 {
+    if !(1..=31).contains(&day) {
         return None;
     }
 

--- a/src/workdir.rs
+++ b/src/workdir.rs
@@ -113,11 +113,7 @@ impl WorkDir {
         let (mut crawled, last_seen_modified, remote_url, work_dir_path) =
             if let Some(ref remote_url) = config.remote_url {
                 // Remote site: fetch items from API
-                log::info!(
-                    "Loading remote site '{}' from {}",
-                    config.slug,
-                    remote_url
-                );
+                log::info!("Loading remote site '{}' from {}", config.slug, remote_url);
 
                 let version_url = format!("{}/v1/version", remote_url);
                 let version_resp: RemoteVersionResponse = reqwest::blocking::get(&version_url)


### PR DESCRIPTION
One-shot mechanical pass:
- `cargo fmt --all` per workspace root
- `cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged` per workspace root

Establishes a clean baseline so the on-disk code matches what Rust 1.96's rustfmt/clippy expects.

Part of kj800x/homelab#4.